### PR TITLE
docs: add secrets management guide

### DIFF
--- a/GUIA_DE_SEGREDOS.md
+++ b/GUIA_DE_SEGREDOS.md
@@ -1,0 +1,17 @@
+# Guia de Gestão de Segredos
+
+Este documento descreve como armazenar e tratar credenciais, certificados e outros dados sensíveis usados neste projeto.
+
+## Boas práticas
+
+- Nunca versionar segredos diretamente (senhas, chaves privadas, certificados). Veja [SECURITY.md](SECURITY.md) para uma lista dos itens que devem permanecer fora do Git.
+- Utilize variáveis de ambiente ou arquivos de configuração fora do repositório para guardar credenciais.
+- Prefira gerenciadores seguros como Windows Credential Manager, Azure Key Vault, AWS Secrets Manager ou KeePass para armazenar senhas.
+- Forneça apenas arquivos modelo (`.env.example`, `application.properties.example`) sem credenciais reais.
+- Limite o acesso a segredos em produção e realize rotação periódica.
+- Revise commits com scanners de segredos (por exemplo, `git-secrets`, `trufflehog`).
+- Em caso de vazamento, revogue e gere novas chaves imediatamente seguindo as políticas descritas em [SECURITY.md](SECURITY.md).
+
+## Referências
+
+- [SECURITY.md](SECURITY.md) – itens não versionados e recomendações de armazenamento.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ O foco é mostrar como projetar, configurar e operar um ambiente de servidor Win
 <a id="anc-seguranca"></a>
 ## 🛡️ Segurança
 
-Veja `SECURITY.md` e `SECRETS_GUIDE.md`.  
+Veja [SECURITY.md](SECURITY.md) e [GUIA_DE_SEGREDOS.md](GUIA_DE_SEGREDOS.md).  
 Nada sensível (senhas, `.pfx`, chaves DKIM) é versionado aqui.  
 
 ---


### PR DESCRIPTION
## Summary
- add guide for handling secrets and link to SECURITY.md
- link README to new secrets guide
- rename secrets guide file to Portuguese name

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e5eee1048330bba2881958e7bc69